### PR TITLE
enhance("data" key envelope optional for introspectionQueryResponse)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@anvilco/apollo-server-plugin-introspection-metadata",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A plugin for Apollo Server that allows for adding metadata to GraphQL Introspection Query responses.",
   "author": "Anvil Foundry Inc. <hello@useanvil.com>",
   "license": "MIT",

--- a/src/index.js
+++ b/src/index.js
@@ -72,7 +72,8 @@ export default generateApolloPlugin
  * metadata provided. Can be used standalone for usecases that are not Apollo Server Plugin scenarios.
  *
  * @param  {Object} options.introspectionQueryResponse - THIS PARAM WILL BE MUTATED - An Introspection
- *   Query response object.
+ *   Query response object. "__schema", etc, can either be wrapped in the "data" envelope, or that
+ *   envelope can have been omitted.
  *
  * @param  {Object} options.schemaMetadata - An object containing the
  *   metadata we'd like to augment any Introspection Query responses with, grouped by kind. Should be
@@ -120,7 +121,7 @@ export const addMetadata = ({
 } = {}) => {
   const {
     types = [],
-  } = (response?.data?.__schema || {})
+  } = (response?.data?.__schema || response?.__schema || {})
 
   // Go through all the types in the Introspection Query response and augment them
   types.forEach((type) => augmentType({ type, schemaMetadata }))

--- a/test/src/index.test.js
+++ b/test/src/index.test.js
@@ -254,5 +254,22 @@ describe('src/index.js', function () {
         })
       })
     })
+
+    context('__schema not nested in "data" key', function () {
+      def('introspectionQueryResponse', () => {
+        return generateIntrospectionQueryResponse().data
+      })
+
+      it('adds metadata', function () {
+        const response = addMetadata($.params)
+        expect(response).to.be.ok
+        const { types } = response.__schema
+
+        const MyType = findType({ types, name: 'MyType' })
+        expect(MyType).to.be.ok
+
+        expect(MyType.metadata).to.eql(defaultMetadata)
+      })
+    })
   })
 })


### PR DESCRIPTION
Some users/use-cases may provide the Introspection Query Response with the `data` envelope removed, while others may not. This seems like it would be a common thing to do out there, so this will support either case:

```js
introspectionQueryResponse = {
  data: {
    __schema: {...},
    ...
  }
}
```

or 

```js
introspectionQueryResponse = {
  __schema: {...},
  ...
}
```