### PR TITLE
chore: Upgrade Lodash

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
     "test:debug:watch": "nodemon -x 'yarn test:debug'"
   },
   "dependencies": {
-    "lodash.get": "^4.4.2",
-    "lodash.set": "^4.3.2"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@babel/cli": "^7.17.6",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
-import set from 'lodash.set'
-import get from 'lodash.get'
+import set from 'lodash/set'
+import get from 'lodash/get'
 
 export const REGEX_INTROSPECTION_QUERY = /\b(__schema|__type)\b/
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2128,10 +2128,10 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash.set@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
-  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@4.1.0:
   version "4.1.0"


### PR DESCRIPTION
`lodash.get` and `lodash.set` no longer receive updates, they are bundled into `lodash`.

This fixes a security issue and closes #137.

Maintainer: once this is released, please bump Spectaql which has this package as a dependency, it is currently vulnerable.